### PR TITLE
Update DataPullTest.py

### DIFF
--- a/DataPullTest.py
+++ b/DataPullTest.py
@@ -89,10 +89,10 @@ def create_matrix(from_this_date, until_this_date, season):
             # get the date
             date = raw_game_stats[1].get_text()
             date = datetime.datetime(int(date[0:4]), int(date[5:7]), int(date[8:]))
-            # don't collect this data if we haven't reached the start date and break inner loop
+            # don't collect this data if we haven't reached the start date and restart loop
             if date < from_this_date:
                 continue
-            # don't collect this data if we've passed the until date and restart loop
+            # don't collect this data if we've passed the until date and break loop
             if date >= until_this_date:
                 break_from_outer_loop = True
                 break;

--- a/DataPullTest.py
+++ b/DataPullTest.py
@@ -201,8 +201,8 @@ def simulation(season):
         # Construct the averages to be used as validation data
         validation_data = construct_validation_data(daily_data, team_histories)
         daily_predictions = model.predict(validation_data)
-        np.append(all_predictions, daily_predictions)
-        np.append(all_targets, expected)
+        all_predictions = np.append(all_predictions, daily_predictions)
+        all_targets = np.append(all_targets, expected)
         print(current_date)
         print(zip(daily_predictions, expected))
         # Replace n oldest entries in training/target sets with n games from today
@@ -214,7 +214,7 @@ def simulation(season):
         # Retrain the model with the actual outcomes of the day's games
         'training_set, target = run_PCA(training_set, target)'
         model.fit(training_set, target)
-    return daily_predictions, all_targets
+    return all_predictions, all_targets
     pass
 
 


### PR DESCRIPTION
Added from_date and season inputs to create_matrix() to make it possible to pull in data from previous seasons and single day's games
Created simulation(), which predicts every game in a given season, using rolling training set.  Returns predictions along with expected results
Moved PCA to its own function, so it can be repeated after every day with the rolling data set
Run simulation in main() and analyze results, then print precision, recall, and f1 to console
